### PR TITLE
adding android debug host

### DIFF
--- a/snaplapse/settings.py
+++ b/snaplapse/settings.py
@@ -34,6 +34,7 @@ ALLOWED_HOSTS = [
     'snaplapse.herokuapp.com',
     '127.0.0.1',
     'localhost',
+    '10.0.2.2'
 ]
 
 


### PR DESCRIPTION
Debugging on android uses http://10.0.2.2:8000 instead of http://localhost:8000