### PR TITLE
fix dupe likes/flags

### DIFF
--- a/api/models/flag.py
+++ b/api/models/flag.py
@@ -8,3 +8,6 @@ class Flag(models.Model):
     user = models.ForeignKey(User, related_name='flags', on_delete=models.CASCADE)
     photo = models.ForeignKey(Photo, related_name='flags', on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'photo')

--- a/api/models/like.py
+++ b/api/models/like.py
@@ -8,3 +8,6 @@ class Like(models.Model):
     user = models.ForeignKey(User, related_name='likes', on_delete=models.CASCADE)
     photo = models.ForeignKey(Photo, related_name='likes', on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = ('user', 'photo')


### PR DESCRIPTION
user 2 likes photo 4 -> succeed
```
~ ➜ curl \
-X POST \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
-d '{"user":"2","photo":"4"}' \
localhost:8000/api/likes/
{"id":1,"user":2,"photo":4,"created":"2023-02-22T19:42:04.993128Z"}%
```
user 2 likes photo 4 again -> fail
```
~ ➜ curl \
-X POST \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
-d '{"user":"2","photo":"4"}' \
localhost:8000/api/likes/
{"non_field_errors":["The fields user, photo must make a unique set."]}%
```
user 3 likes photo 4 -> succeed
```
~ ➜ curl \
-X POST \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
-d '{"user":"3","photo":"4"}' \
localhost:8000/api/likes/
{"id":4,"user":3,"photo":4,"created":"2023-02-22T19:45:35.303345Z"}%
```