### PR TITLE
Fixed recommender bug caused by mismatched location matrices

### DIFF
--- a/recommendations/recommender.py
+++ b/recommendations/recommender.py
@@ -3,6 +3,7 @@ import time
 import sys
 import pandas as pd
 import requests
+import math
 
 from sklearn.neighbors import NearestNeighbors
 
@@ -11,14 +12,24 @@ pd.options.display.max_columns = None
 
 def load_data(host, latitude, longitude, radius):
     # Get locations
-    nearby_locations_url = f"http://{host}/api/locations/nearby?coordinates={latitude},{longitude}&radius={radius}"
-    get_locations = json.loads(requests.get(nearby_locations_url, timeout=10).content.decode("utf-8"))
+    locations_url = f"http://{host}/api/locations/"
+    get_locations = json.loads(requests.get(locations_url, timeout=10).content.decode("utf-8"))
     locations_list = []
     for location in get_locations['results']:
         locations_list.append((location['id'], location['name'], location['latitude'], location['longitude'], location['categories'], location['google_id']))
     locations = pd.DataFrame(locations_list, columns = ['location_id', 'name', 'latitude', 'longitude', 'categories', 'google_id']).sort_values(by=['location_id'])
     locations.set_index('location_id', drop=False, inplace=True)
     # print(locations)
+
+    lat1 = latitude - (radius / 6378000) * (180 / math.pi)
+    lat2 = latitude + (radius / 6378000) * (180 / math.pi)
+    lng1 = longitude - (radius / 6378000) * (180 / math.pi) / math.cos(latitude * math.pi/180)
+    lng2 = longitude + (radius / 6378000) * (180 / math.pi) / math.cos(latitude * math.pi/180)
+    nearby_locations = locations[(locations['latitude'] >= lat1) 
+                                 & (locations['latitude'] <= lat2) 
+                                 & (locations['longitude'] >= lng1) 
+                                 & (locations['longitude'] <= lng2)]
+    # print(nearby_locations)
 
     # Get likes
     likes_url = f"http://{host}/api/locations/likes/"
@@ -30,7 +41,7 @@ def load_data(host, latitude, longitude, radius):
     likes.set_index('location_id', drop=False, inplace=True)
     # print(likes)
 
-    return likes, locations
+    return likes, locations, nearby_locations
 
 def dataframe_to_json_list(dataframe, indices):
     result = []
@@ -40,15 +51,28 @@ def dataframe_to_json_list(dataframe, indices):
 
     return result
 
-def generate_affinity_recommendations(user_id, likes, locations, num_recs):
-    locations_with_categories = locations.copy(deep=True)
+def generate_affinity_recommendations(user_id, likes, locations, nearby_locations, num_recs):
+    locations_with_categories = locations.copy(deep=True)           # training data to get user's category affinity model - all locations
+    nearby_locations_categories = nearby_locations.copy(deep=True)  # test data to get recommended locations - only nearby locations
 
     # Iterate through locations and append the location categories as columns of 1s or 0s. 1 if the location at the present index contains the category and 0 if not.
     for index, row in locations.iterrows():
         for category in row['categories']:
             locations_with_categories.at[index, category] = 1
+    
+    # Fill each nearby location with the extra categories as 0
+    for category in locations_with_categories.columns:
+        if category not in nearby_locations_categories.columns:
+            for index, row in nearby_locations_categories.iterrows():
+                if category in row['categories']:
+                    nearby_locations_categories.at[index, category] = 1
+                else:
+                    nearby_locations_categories.at[index, category] = 0
+    nearby_locations_categories = nearby_locations_categories.rename(columns={'location_id': 'id'})
+
     # Fill in the NaN values with 0
     locations_with_categories = locations_with_categories.fillna(0)
+    nearby_locations_categories = nearby_locations_categories.fillna(0).sort_values('id')
 
     # Get only the likes of the indicated user
     user_likes = likes[likes['user_id'] == user_id]
@@ -66,7 +90,7 @@ def generate_affinity_recommendations(user_id, likes, locations, num_recs):
     user_affinities = user_categories.T.dot(user_likes.likes)
 
     # Delete unnecessary columns
-    locations_with_categories.drop(['location_id','name','latitude','longitude','categories','google_id'], axis=1, inplace=True)
+    nearby_locations_categories.drop(['id','name','latitude', 'longitude','categories','google_id'], axis=1, inplace=True)
 
     user_affinities = user_affinities.values.reshape(1, -1)
 
@@ -76,24 +100,24 @@ def generate_affinity_recommendations(user_id, likes, locations, num_recs):
         'algorithm': 'brute',
         'metric': 'cosine',
         'n_jobs': -1})
-    model.fit(locations_with_categories.values)
+    model.fit(nearby_locations_categories.values)
     indices = model.kneighbors(user_affinities, n_neighbors=num_recs, return_distance=False)
-    knn_index_to_loc_index = list(locations_with_categories.index.values[indices])[0]
+    knn_index_to_loc_index = list(nearby_locations_categories.index.values[indices])[0]
 
     # Create list of recommendations
-    locations = locations.rename(columns={'location_id': 'id'})
-    affinity_recs = dataframe_to_json_list(locations, knn_index_to_loc_index)
+    nearby_locations = nearby_locations.rename(columns={'location_id': 'id'})
+    affinity_recs = dataframe_to_json_list(nearby_locations, knn_index_to_loc_index)
     
     return affinity_recs
 
-def generate_user_recommendations(likes, locations, affinity_recs, num_recs):
-    locations = locations.rename(columns={'location_id': 'id'})
-    num_locations = len(locations.index)
+def generate_user_recommendations(likes, nearby_locations, affinity_recs, num_recs):
+    nearby_locations = nearby_locations.rename(columns={'location_id': 'id'})
+    num_locations = len(nearby_locations.index)
 
     pivot_likes = likes.pivot(columns='user_id', values='likes')
 
     # Append locations without likes as 0 likes for all users
-    for index in locations.index:
+    for index in nearby_locations.index:
         if index not in pivot_likes.index: 
             location = pd.DataFrame(0, index=[index], columns=pivot_likes.columns)
             pivot_likes = pd.concat([pivot_likes, location])
@@ -122,7 +146,7 @@ def generate_user_recommendations(likes, locations, affinity_recs, num_recs):
             indices = model.kneighbors(seed, n_neighbors=n, return_distance=False)
             
             # Check list of neighbors for a non-duplicate to add as rec
-            for id in list(locations.index.values[indices])[0]:
+            for id in list(nearby_locations.index.values[indices])[0]:
                 if not any(r['id'] == id for r in affinity_recs) and id not in user_rec_ids:
                     user_rec_ids.append(id)
                     found = True
@@ -134,28 +158,28 @@ def generate_user_recommendations(likes, locations, affinity_recs, num_recs):
             if n < num_locations: # if still not found, generate 10 more and keep checking
                 n = n + 10 if num_locations > n + 10 else num_locations
             else: # if out of locations return as is
-                user_recs = dataframe_to_json_list(locations, user_rec_ids)
+                user_recs = dataframe_to_json_list(nearby_locations, user_rec_ids)
                 return user_recs
 
-    user_recs = dataframe_to_json_list(locations, user_rec_ids)
+    user_recs = dataframe_to_json_list(nearby_locations, user_rec_ids)
 
     return user_recs
 
 def make_recommendations(host, user_id, latitude, longitude, radius, num_recs):
-    likes, locations = load_data(host, latitude, longitude, radius)
-    if len(locations) == 0:
-        return locations.to_dict('records')
+    likes, locations, nearby_locations = load_data(host, latitude, longitude, radius)
+    if len(nearby_locations) == 0:
+        return nearby_locations.to_dict('records')
     if len(likes) == 0:
-        return locations.rename(columns={'location_id': 'id'}).head(num_recs).to_dict('records')
+        return nearby_locations.rename(columns={'location_id': 'id'}).head(num_recs).to_dict('records')
 
-    if len(locations) < num_recs:
-        num_recs = len(locations)
+    if len(nearby_locations) < num_recs:
+        num_recs = len(nearby_locations)
 
     num_affinity_recs = num_recs//2 if num_recs%2 == 0 else num_recs//2 + 1
     num_user_recs = num_recs//2
 
-    affinity_recs = generate_affinity_recommendations(user_id, likes, locations, num_affinity_recs)
-    user_recs = generate_user_recommendations(likes, locations, affinity_recs, num_user_recs)
+    affinity_recs = generate_affinity_recommendations(user_id, likes, locations, nearby_locations, num_affinity_recs)
+    user_recs = generate_user_recommendations(likes, nearby_locations, affinity_recs, num_user_recs)
 
     recommendations = []
     alength = len(affinity_recs)


### PR DESCRIPTION
complete aids

How it was caused:
- User has likes in locations far apart
- Get recommendations in range of only some liked locations (not all)
- Algo used _all_ liked locations mult by only _nearby_ locations to create affinity matrix, since 
nearbylocations < likedlocations matrix mismatch occurred when trying to dot product and thus error

How it was fixed:
- Use ALL locations to generate affinity matrix, only use nearby locations to find recommendable locations